### PR TITLE
Fix core_course_category namespace resolution

### DIFF
--- a/classes/text_filter.php
+++ b/classes/text_filter.php
@@ -23,7 +23,9 @@
 
 namespace filter_courselist;
 
+use core_course_category;
 use core_course\customfield\course_handler;
+
 
 /**
  * Implementation of the Moodle filter API for the Course list filter.


### PR DESCRIPTION
Import Moodle core_course_category to prevent PHP resolving it as filter_courselist\core_course_category when using subcategories.